### PR TITLE
Actually fix 'Could not resolve "./SideBar"' for linux-based systems

### DIFF
--- a/src/pages/dashboard/Blooks.jsx
+++ b/src/pages/dashboard/Blooks.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { useAuth } from "../../context/AuthContext";
 import allBlooks, { freeBlooks, rarityColors } from "../../blooks/allBlooks";
 import packs, { GenericSetBackground } from "../../blooks/packs";

--- a/src/pages/dashboard/Discover.jsx
+++ b/src/pages/dashboard/Discover.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { setActivity } from "../../utils/discordRPC";
 import { useAuth } from "../../context/AuthContext";
 import { useState } from "react";

--- a/src/pages/dashboard/Favorites.jsx
+++ b/src/pages/dashboard/Favorites.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { setActivity } from "../../utils/discordRPC";
 function Favorites() {
     useEffect(() => {

--- a/src/pages/dashboard/GameSet.jsx
+++ b/src/pages/dashboard/GameSet.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { setActivity } from "../../utils/discordRPC";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";

--- a/src/pages/dashboard/Market.jsx
+++ b/src/pages/dashboard/Market.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import packs, { market, packTop, token } from "../../blooks/packs";
 import "./market.css";
 import { setActivity } from "../../utils/discordRPC";

--- a/src/pages/dashboard/SetCreator.jsx
+++ b/src/pages/dashboard/SetCreator.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { setActivity } from "../../utils/discordRPC";
 function SetCreator() {
     useEffect(() => {

--- a/src/pages/dashboard/Sets.jsx
+++ b/src/pages/dashboard/Sets.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { setActivity } from "../../utils/discordRPC";
 function Sets() {
     useEffect(() => {

--- a/src/pages/dashboard/Settings.jsx
+++ b/src/pages/dashboard/Settings.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import Sidebar from "./SideBar";
+import Sidebar from "./SideBar.jsx";
 import { setActivity } from "../../utils/discordRPC";
 function Settings() {
     useEffect(() => {


### PR DESCRIPTION
Currently, when compiling on Linux, it gives an error involving file extensions:
```bash
Could not resolve "./SideBar" from "src/pages/dashboard/Market.jsx"
file: /home/runner/work/BetterBlooket-Releases/BetterBlooket-Releases/src/pages/dashboard/Market.jsx
error during build:
RollupError: Could not resolve "./SideBar" from "src/pages/dashboard/Market.jsx"
    at error (file:///home/runner/work/BetterBlooket-Releases/BetterBlooket-Releases/node_modules/rollup/dist/es/shared/node-entry.js:2245:30)
    at ModuleLoader.handleInvalidResolvedId (file:///home/runner/work/BetterBlooket-Releases/BetterBlooket-Releases/node_modules/rollup/dist/es/shared/node-entry.js:24654:24)
    at file:///home/runner/work/BetterBlooket-Releases/BetterBlooket-Releases/node_modules/rollup/dist/es/shared/node-entry.js:24616:26
       Error beforeBuildCommand `npm run build` failed with exit code 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Command failed with exit code 1: yarn tauri build
```
This error affects a total of 9 files, 1 of which has already been fixed in commit [48900e6](https://github.com/Minesraft2/BetterBlooket/commit/48900e6e95883fc10481b8a8c7ce43b5e22b91b5). This pull request aims to fix that/